### PR TITLE
Add String.Contains() and StringComparison enum

### DIFF
--- a/dist/index.ts
+++ b/dist/index.ts
@@ -17,8 +17,7 @@ export class String {
         }
     }
 
-    public static Contains(value: string, search: string, comparison: StringComparison = StringComparison.Ordinal): boolean
-    {
+    public static Contains(value: string, search: string, comparison: StringComparison = StringComparison.Ordinal): boolean {
         try {
             if (value == null || value == 'undefined' || search == null || search == 'undefined')
                 return false;
@@ -29,6 +28,73 @@ export class String {
         catch (e) {
             console.log(e);
             return false;
+        }
+    }
+
+    public static Equals(value: string, compareTo: string, comparison: StringComparison = StringComparison.Ordinal): boolean {
+        try {
+            if (value == null || value == 'undefined') {
+                return compareTo == null || compareTo == 'undefined';
+            }
+            if (compareTo == null || compareTo == 'undefined') {
+                return false;
+            }
+            const compareValue = comparison == StringComparison.Ordinal ? value.toString() : value.toString().toLocaleLowerCase();
+            const compareToValue = comparison == StringComparison.Ordinal ? compareTo.toString() : compareTo.toString().toLocaleLowerCase();
+            return compareValue == compareToValue;
+        }
+        catch (e) {
+            console.log(e);
+            return false;
+        }
+    }
+
+    public static Compare(value: string, compareTo: string, comparison: StringComparison = StringComparison.Ordinal): number {
+        try {
+            if (value == null || value == 'undefined') {
+                return (compareTo == null || compareTo == 'undefined') ? 0 : -1;
+            }
+            if (compareTo == null || compareTo == 'undefined') {
+                return 1;
+            }
+            const compareValue = comparison == StringComparison.Ordinal ? value.toString() : value.toString().toLocaleLowerCase();
+            const compareToValue = comparison == StringComparison.Ordinal ? compareTo.toString() : compareTo.toString().toLocaleLowerCase();
+            if (compareValue == compareToValue) {
+                return 0;
+            }
+            return compareValue > compareToValue ? 1 : -1;
+        }
+        catch (e) {
+            console.log(e);
+            return 0;
+        }
+    }
+
+    public static ToLower(value: string): string
+    {
+        try {
+            if (value == null || value == 'undefined') {
+                return String.Empty;
+            }
+            return value.toLocaleLowerCase();
+        }
+        catch (e) {
+            console.log(e);
+            return String.Empty;
+        }
+    }
+
+    public static ToUpper(value: string): string
+    {
+        try {
+            if (value == null || value == 'undefined') {
+                return String.Empty;
+            }
+            return value.toLocaleUpperCase();
+        }
+        catch (e) {
+            console.log(e);
+            return String.Empty;
         }
     }
 

--- a/dist/index.ts
+++ b/dist/index.ts
@@ -17,6 +17,21 @@ export class String {
         }
     }
 
+    public static Contains(value: string, search: string, comparison: StringComparison = StringComparison.Ordinal): boolean
+    {
+        try {
+            if (value == null || value == 'undefined' || search == null || search == 'undefined')
+                return false;
+            const seachIn = comparison == StringComparison.Ordinal ? value.toString() : value.toString().toLocaleLowerCase();
+            const seachTerm = comparison == StringComparison.Ordinal ? search.toString() : search.toString().toLocaleLowerCase();
+            return seachIn.indexOf(seachTerm) !== -1;
+        }
+        catch (e) {
+            console.log(e);
+            return false;
+        }
+    }
+
     public static Join(delimiter: string, ...args: (string | object | Array<any>)[]): string {
         try {
             let firstArg = args[0];
@@ -236,4 +251,9 @@ export class StringBuilder {
     public Clear() {
         this.Values = [];
     }
+}
+
+export enum StringComparison {
+    Ordinal,
+    OrdinalIgnoreCase,
 }


### PR DESCRIPTION
Hi,

I have added a static `String.Contains()` method with an optional parameter of a also added `StringComparison` enum. Makes string comparisons much more C#-like.