### PR TITLE
docs(README): fix broken CircleCI badge, link to GitHub Actions CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-[![CircleCI](https://circleci.com/gh/sevensc/typescript-string-operations.svg?style=shield)](https://app.circleci.com/pipelines/github/sevensc/typescript-string-operations)
+[![CI](https://github.com/sevensc/typescript-string-operations/actions/workflows/ci.yml/badge.svg)](https://github.com/sevensc/typescript-string-operations/actions/workflows/ci.yml)
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=sevensc_typescript-string-operations&metric=alert_status)](https://sonarcloud.io/dashboard?id=sevensc_typescript-string-operations)
 ![npm](https://img.shields.io/npm/v/typescript-string-operations)
 ![npm](https://img.shields.io/npm/dw/typescript-string-operations)


### PR DESCRIPTION
## Summary
- Ersetzt das tote CircleCI-Badge im README durch das GitHub-Actions-CI-Badge, seit die CI zu GitHub Actions migriert wurde.

Nebenbei: dies ist der erste Commit seit dem npm-Trusted-Publishing-Setup, der einen `semantic-release`-Patch-Release auslöst (`docs(README)` zählt nach der Standard-Angular-Konvention als releasable Patch).

## Test plan
- [ ] Merge nach main beobachten: `release.yml` sollte einen Patch-Release (1.6.2) erzeugen und automatisch zu npm publishen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)