### PR TITLE
ci: fix release workflow crash from OIDC/registry-url mismatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,6 @@ jobs:
         with:
           node-version: 24.18.1
           cache: yarn
-          registry-url: https://registry.npmjs.org
       - run: yarn install --frozen-lockfile --ignore-scripts
       - run: yarn lint
       - run: yarn build


### PR DESCRIPTION
## Summary
- Der `release`-Workflow (getriggert durch den Merge von #131) ist bereits zweimal gescheitert, noch vor `semantic-release` — beim `yarn install`-Schritt.
- Ursache: `actions/setup-node` schreibt bei gesetztem `registry-url` eine `.npmrc` mit `_authToken=${NODE_AUTH_TOKEN}`. Diese Env-Variable existiert nicht mehr, seit wir auf npm Trusted Publishing (OIDC) umgestellt haben — Yarn Classic bricht beim Versuch, sie aufzulösen, hart ab.
- Fix: `registry-url` beim `setup-node`-Schritt entfernen. Trusted Publishing braucht dafür nur `id-token: write`, keine `.npmrc`-Vorkonfiguration.

## Test plan
- [ ] Nach Merge: `release.yml` sollte durchlaufen und den ausstehenden Patch-Release (aus #131, `docs(README)`) erfolgreich zu npm publishen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)