### PR TITLE
fix: don't treat the literal string "undefined" as blank

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -46,7 +46,7 @@ export class String {
 
     public static isNullOrWhiteSpace(value: string | null): boolean {
         try {
-            if (value == null || value == 'undefined') {
+            if (value == null) {
                 return true;
             }
 

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -44,6 +44,16 @@ describe('String.IsNullOrWhitespace', () => {
         result = isNullOrWhiteSpace(teststring);
         expect(result).toBe(false);
     });
+
+    it('should return false for the literal string "undefined"', () => {
+        const teststring = 'undefined';
+        let result = String.IsNullOrWhiteSpace(teststring);
+        expect(result).toBe(false);
+        result = String.isNullOrWhiteSpace(teststring);
+        expect(result).toBe(false);
+        result = isNullOrWhiteSpace(teststring);
+        expect(result).toBe(false);
+    });
 });
 
 describe('String.Format Number Pattern', () => {


### PR DESCRIPTION
## Summary
- `isNullOrWhiteSpace` compared against the string `'undefined'` in addition to `null` — the actual text "undefined" (e.g. real user input) was incorrectly reported as blank. `value == null` already covers real `undefined` via loose equality, so the extra check was redundant and incorrect.
- Adds a regression test covering the literal string case.

This is the first real `fix:` commit since the npm Trusted Publishing setup — expect `semantic-release` to cut a patch release (1.6.2) and publish it to npm automatically on merge.

## Test plan
- [x] `yarn lint`, `yarn build`, `yarn test` pass locally (40/40 tests)
- [ ] After merge: `release.yml` publishes 1.6.2 to npm via trusted publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)